### PR TITLE
Improve the settings dialog

### DIFF
--- a/src/org/openstreetmap/josm/plugins/conflation/MatchFinderPanel.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/MatchFinderPanel.java
@@ -1,15 +1,34 @@
 package org.openstreetmap.josm.plugins.conflation;
 
-import com.vividsolutions.jcs.conflate.polygonmatch.*;
-import java.awt.Dimension;
-import javax.swing.*;
-import net.miginfocom.swing.MigLayout;
 import static org.openstreetmap.josm.tools.I18n.tr;
+
+import java.awt.Dimension;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JComboBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+
+import net.miginfocom.swing.MigLayout;
+
+import com.vividsolutions.jcs.conflate.polygonmatch.AbstractDistanceMatcher;
+import com.vividsolutions.jcs.conflate.polygonmatch.BasicFCMatchFinder;
+import com.vividsolutions.jcs.conflate.polygonmatch.CentroidDistanceMatcher;
+import com.vividsolutions.jcs.conflate.polygonmatch.ChainMatcher;
+import com.vividsolutions.jcs.conflate.polygonmatch.DisambiguatingFCMatchFinder;
+import com.vividsolutions.jcs.conflate.polygonmatch.FCMatchFinder;
+import com.vividsolutions.jcs.conflate.polygonmatch.FeatureMatcher;
+import com.vividsolutions.jcs.conflate.polygonmatch.HausdorffDistanceMatcher;
+import com.vividsolutions.jcs.conflate.polygonmatch.IdenticalFeatureFilter;
+import com.vividsolutions.jcs.conflate.polygonmatch.OneToOneFCMatchFinder;
 
 
 public class MatchFinderPanel extends JPanel {
-    private JComboBox<String> matchFinderComboBox;
-    private CentroidDistanceComponent centroidDistanceComponent;
+    private final JComboBox<String> matchFinderComboBox;
+    private final CentroidDistanceComponent centroidDistanceComponent;
 
     public MatchFinderPanel() {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));

--- a/src/org/openstreetmap/josm/plugins/conflation/MatchFinderPanel.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/MatchFinderPanel.java
@@ -12,6 +12,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JSpinner;
 import javax.swing.SpinnerNumberModel;
+import javax.swing.border.CompoundBorder;
 
 import net.miginfocom.swing.MigLayout;
 
@@ -33,7 +34,9 @@ public class MatchFinderPanel extends JPanel {
 
     public MatchFinderPanel() {
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-        setBorder(BorderFactory.createTitledBorder(tr("Match finder settings")));
+        setBorder(new CompoundBorder(
+                BorderFactory.createTitledBorder(tr("Match finder settings")),
+                BorderFactory.createEmptyBorder(5,5,5,5)));
 
         String[] matchFinderStrings = {"DisambiguatingFCMatchFinder", "OneToOneFCMatchFinder" };
         matchFinderComboBox = new JComboBox<>(matchFinderStrings);

--- a/src/org/openstreetmap/josm/plugins/conflation/MatchFinderPanel.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/MatchFinderPanel.java
@@ -5,6 +5,7 @@ import static org.openstreetmap.josm.tools.I18n.tr;
 import java.awt.Dimension;
 
 import javax.swing.BorderFactory;
+import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
@@ -39,10 +40,14 @@ public class MatchFinderPanel extends JPanel {
         matchFinderComboBox.setSelectedIndex(0);
         JPanel comboboxPanel = new JPanel();
         comboboxPanel.setBorder(BorderFactory.createTitledBorder(tr("Match finder method")));
+        comboboxPanel.setAlignmentX(LEFT_ALIGNMENT);
         comboboxPanel.add(matchFinderComboBox);
         add(comboboxPanel);
 
+        add(Box.createRigidArea(new Dimension(0, 10)));
+
         centroidDistanceComponent = new CentroidDistanceComponent();
+        centroidDistanceComponent.setAlignmentX(LEFT_ALIGNMENT);
         add(centroidDistanceComponent);
     }
 

--- a/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
@@ -3,16 +3,19 @@ package org.openstreetmap.josm.plugins.conflation;
 
 import static org.openstreetmap.josm.tools.I18n.tr;
 
+import java.awt.Dimension;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
 
 import javax.swing.BorderFactory;
+import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
+import javax.swing.border.CompoundBorder;
 
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.JosmAction;
@@ -67,44 +70,80 @@ public class SettingsDialog extends ExtendedDialog {
         referencePanel = new JPanel();
         referenceLayerLabel = new JLabel();
         referenceSelectionLabel = new JLabel();
+
         jPanel3 = new JPanel();
         restoreReferenceButton = new JButton(new RestoreReferenceAction());
         freezeReferenceButton = new JButton(new FreezeReferenceAction());
+
         subjectPanel = new JPanel();
         subjectLayerLabel = new JLabel();
         subjectSelectionLabel = new JLabel();
+
         jPanel5 = new JPanel();
         restoreSubjectButton = new JButton(new RestoreSubjectAction());
         freezeSubjectButton = new JButton(new FreezeSubjectAction());
+
         JPanel pnl = new JPanel();
         pnl.setLayout(new BoxLayout(pnl, BoxLayout.PAGE_AXIS));
-        referencePanel.setBorder(BorderFactory.createTitledBorder(tr("Reference")));
-        referencePanel.setLayout(new BoxLayout(referencePanel, BoxLayout.PAGE_AXIS));
+
+        referencePanel.setBorder(new CompoundBorder(
+                BorderFactory.createTitledBorder(tr("Reference")),
+                BorderFactory.createEmptyBorder(5,5,5,5)));
+        referencePanel.setAlignmentX(LEFT_ALIGNMENT);
+        referencePanel.setLayout(new BoxLayout(referencePanel,
+                BoxLayout.PAGE_AXIS));
+
         referenceLayerLabel.setText("(none)");
+        referenceLayerLabel.setAlignmentX(LEFT_ALIGNMENT);
         referencePanel.add(referenceLayerLabel);
         referenceSelectionLabel.setText("Rel.:0 / Ways:0 / Nodes: 0");
+        referenceSelectionLabel.setAlignmentX(LEFT_ALIGNMENT);
         referencePanel.add(referenceSelectionLabel);
+
         jPanel3.setLayout(new BoxLayout(jPanel3, BoxLayout.LINE_AXIS));
+        jPanel3.setAlignmentX(LEFT_ALIGNMENT);
+        jPanel3.add(Box.createHorizontalGlue());
         restoreReferenceButton.setText(tr("Restore"));
         jPanel3.add(restoreReferenceButton);
+        jPanel3.add(Box.createRigidArea(new Dimension(5, 0)));
         jPanel3.add(freezeReferenceButton);
+        jPanel3.add(Box.createHorizontalGlue());
+
+        referencePanel.add(Box.createRigidArea(new Dimension(0, 5)));
         referencePanel.add(jPanel3);
         pnl.add(referencePanel);
-        subjectPanel.setBorder(BorderFactory.createTitledBorder(tr("Subject")));
+
+        pnl.add(Box.createRigidArea(new Dimension(0, 10)));
+
+        subjectPanel.setBorder(new CompoundBorder(
+                BorderFactory.createTitledBorder(tr("Subject")),
+                BorderFactory.createEmptyBorder(5,5,5,5)));
+        subjectPanel.setAlignmentX(LEFT_ALIGNMENT);
         subjectPanel.setLayout(new BoxLayout(subjectPanel, BoxLayout.PAGE_AXIS));
         subjectLayerLabel.setText("(none)");
+        subjectLayerLabel.setAlignmentX(LEFT_ALIGNMENT);
         subjectPanel.add(subjectLayerLabel);
         subjectSelectionLabel.setText("Rel.:0 / Ways:0 / Nodes: 0");
+        subjectSelectionLabel.setAlignmentX(LEFT_ALIGNMENT);
         subjectPanel.add(subjectSelectionLabel);
+
         jPanel5.setLayout(new BoxLayout(jPanel5, BoxLayout.LINE_AXIS));
+        jPanel5.setAlignmentX(LEFT_ALIGNMENT);
+        jPanel5.add(Box.createHorizontalGlue());
         restoreSubjectButton.setText(tr("Restore"));
         jPanel5.add(restoreSubjectButton);
+        jPanel5.add(Box.createRigidArea(new Dimension(5, 0)));
         freezeSubjectButton.setText(tr("Freeze"));
         jPanel5.add(freezeSubjectButton);
+        jPanel5.add(Box.createHorizontalGlue());
+        subjectPanel.add(Box.createRigidArea(new Dimension(0, 5)));
         subjectPanel.add(jPanel5);
         pnl.add(subjectPanel);
 
+        pnl.add(Box.createRigidArea(new Dimension(0, 10)));
+
         matchFinderPanel = new MatchFinderPanel();
+        matchFinderPanel.setAlignmentX(LEFT_ALIGNMENT);
         pnl.add(matchFinderPanel);
 
         setContent(pnl);

--- a/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
@@ -107,7 +107,8 @@ public class SettingsDialog extends ExtendedDialog {
         referenceLayerPanel.add(referenceLayerLabel);
         referencePanel.add(referenceLayerPanel);
 
-        referenceSelectionLabel.setText("Rel.:0 / Ways:0 / Nodes: 0");
+        referenceSelectionLabel.setText(tr("{0}: 0 / {1}: 0 / {2}: 0",
+                "Relations", "Ways", "Nodes"));
         referenceSelectionLabel.setAlignmentX(LEFT_ALIGNMENT);
         referencePanel.add(referenceSelectionLabel);
 
@@ -142,8 +143,8 @@ public class SettingsDialog extends ExtendedDialog {
         subjectLayerPanel.add(subjectLayerLabel);
         subjectPanel.add(subjectLayerPanel);
 
-        subjectSelectionLabel.setText("Rel.:0 / Ways:0 / Nodes: 0");
-        subjectSelectionLabel.setAlignmentX(LEFT_ALIGNMENT);
+        subjectSelectionLabel.setText(tr("{0}: 0 / {1}: 0 / {2}: 0",
+                "Relations", "Ways", "Nodes"));
         subjectPanel.add(subjectSelectionLabel);
 
         jPanel5.setLayout(new BoxLayout(jPanel5, BoxLayout.LINE_AXIS));
@@ -282,7 +283,7 @@ public class SettingsDialog extends ExtendedDialog {
     class FreezeReferenceAction extends JosmAction {
 
         public FreezeReferenceAction() {
-            super(tr("Freeze"), null, tr("Freeze subject selection"), null, false);
+            super(tr("Freeze"), null, tr("Freeze reference selection"), null, false);
         }
 
         @Override
@@ -327,9 +328,9 @@ public class SettingsDialog extends ExtendedDialog {
                     numRelations++;
                 }
             }
-            // FIXME: translate correctly
             subjectLayerLabel.setText(subjectLayer.getName());
-            subjectSelectionLabel.setText(String.format("Rel.: %d / Ways: %d / Nodes: %d", numRelations, numWays, numNodes));
+            subjectSelectionLabel.setText(tr("{0}: {1} / {2}: {3} / {4}: {5}",
+                    "Relations", numRelations, "Ways", numWays, "Nodes", numNodes));
         }
         numNodes = 0;
         numWays = 0;
@@ -344,10 +345,9 @@ public class SettingsDialog extends ExtendedDialog {
                     numRelations++;
                 }
             }
-
-            // FIXME: translate correctly
             referenceLayerLabel.setText(referenceLayer.getName());
-            referenceSelectionLabel.setText(String.format("Rel.: %d / Ways: %d / Nodes: %d", numRelations, numWays, numNodes));
+            referenceSelectionLabel.setText(tr("{0}: {1} / {2}: {3} / {4}: {5}",
+                    "Relations", numRelations, "Ways", numWays, "Nodes", numNodes));
         }
 
         //FIXME: properly update match finder settings

--- a/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
@@ -1,22 +1,34 @@
 // License: GPL. See LICENSE file for details. Copyright 2012 by Josh Doe and others.
 package org.openstreetmap.josm.plugins.conflation;
 
+import static org.openstreetmap.josm.tools.I18n.tr;
+
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.List;
-import javax.swing.*;
+
+import javax.swing.BorderFactory;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+
 import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.JosmAction;
-import org.openstreetmap.josm.data.osm.*;
+import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.data.osm.Node;
+import org.openstreetmap.josm.data.osm.OsmPrimitive;
+import org.openstreetmap.josm.data.osm.Relation;
+import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.gui.ExtendedDialog;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
-import static org.openstreetmap.josm.tools.I18n.tr;
 
 /**
  * Dialog for selecting objects and configuring conflation settings
  */
 public class SettingsDialog extends ExtendedDialog {
-    
+
     private JButton freezeReferenceButton;
     private JButton freezeSubjectButton;
     private JPanel jPanel3;
@@ -30,7 +42,7 @@ public class SettingsDialog extends ExtendedDialog {
     private JPanel subjectPanel;
     private JLabel subjectSelectionLabel;
     private MatchFinderPanel matchFinderPanel;
-    
+
     List<OsmPrimitive> subjectSelection = null;
     List<OsmPrimitive> referenceSelection = null;
     OsmDataLayer referenceLayer;
@@ -129,23 +141,23 @@ public class SettingsDialog extends ExtendedDialog {
         settings.setSubjectLayer(subjectLayer);
         settings.setSubjectSelection(subjectSelection);
         settings.setMatchFinder(matchFinderPanel.getMatchFinder());
-        
+
         return settings;
     }
 
-//    /**
-//     * @param settings the settings to set
-//     */
-//    public void setSettings(SimpleMatchSettings settings) {
-//        referenceDataSet = settings.getReferenceDataSet();
-//        referenceLayer = settings.getReferenceLayer();
-//        referenceSelection = settings.getReferenceSelection();
-//        subjectDataSet = settings.getSubjectDataSet();
-//        subjectLayer = settings.getSubjectLayer();
-//        subjectSelection = settings.getSubjectSelection();
-//        update();
-//        //matchFinderPanel.matchFinder = settings.getMatchFinder();
-//    }
+    //    /**
+    //     * @param settings the settings to set
+    //     */
+    //    public void setSettings(SimpleMatchSettings settings) {
+    //        referenceDataSet = settings.getReferenceDataSet();
+    //        referenceLayer = settings.getReferenceLayer();
+    //        referenceSelection = settings.getReferenceSelection();
+    //        subjectDataSet = settings.getSubjectDataSet();
+    //        subjectLayer = settings.getSubjectLayer();
+    //        subjectSelection = settings.getSubjectSelection();
+    //        update();
+    //        //matchFinderPanel.matchFinder = settings.getMatchFinder();
+    //    }
 
     class RestoreSubjectAction extends JosmAction {
 

--- a/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
@@ -93,9 +93,16 @@ public class SettingsDialog extends ExtendedDialog {
         referencePanel.setLayout(new BoxLayout(referencePanel,
                 BoxLayout.PAGE_AXIS));
 
+        JPanel referenceLayerPanel = new JPanel();
+        referenceLayerPanel.setLayout(new BoxLayout(referenceLayerPanel,
+                BoxLayout.LINE_AXIS));
+        referenceLayerPanel.setAlignmentX(LEFT_ALIGNMENT);
+        referenceLayerPanel.add(new JLabel(tr("Layer:")));
+        referenceLayerPanel.add(Box.createRigidArea(new Dimension(5, 0)));
         referenceLayerLabel.setText("(none)");
-        referenceLayerLabel.setAlignmentX(LEFT_ALIGNMENT);
-        referencePanel.add(referenceLayerLabel);
+        referenceLayerPanel.add(referenceLayerLabel);
+        referencePanel.add(referenceLayerPanel);
+
         referenceSelectionLabel.setText("Rel.:0 / Ways:0 / Nodes: 0");
         referenceSelectionLabel.setAlignmentX(LEFT_ALIGNMENT);
         referencePanel.add(referenceSelectionLabel);
@@ -120,9 +127,17 @@ public class SettingsDialog extends ExtendedDialog {
                 BorderFactory.createEmptyBorder(5,5,5,5)));
         subjectPanel.setAlignmentX(LEFT_ALIGNMENT);
         subjectPanel.setLayout(new BoxLayout(subjectPanel, BoxLayout.PAGE_AXIS));
+
+        JPanel subjectLayerPanel = new JPanel();
+        subjectLayerPanel.setLayout(new BoxLayout(subjectLayerPanel,
+                BoxLayout.LINE_AXIS));
+        subjectLayerPanel.setAlignmentX(LEFT_ALIGNMENT);
+        subjectLayerPanel.add(new JLabel(tr("Layer:")));
+        subjectLayerPanel.add(Box.createRigidArea(new Dimension(5, 0)));
         subjectLayerLabel.setText("(none)");
-        subjectLayerLabel.setAlignmentX(LEFT_ALIGNMENT);
-        subjectPanel.add(subjectLayerLabel);
+        subjectLayerPanel.add(subjectLayerLabel);
+        subjectPanel.add(subjectLayerPanel);
+
         subjectSelectionLabel.setText("Rel.:0 / Ways:0 / Nodes: 0");
         subjectSelectionLabel.setAlignmentX(LEFT_ALIGNMENT);
         subjectPanel.add(subjectSelectionLabel);

--- a/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
+++ b/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java
@@ -11,6 +11,7 @@ import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
+import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
@@ -26,6 +27,7 @@ import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.gui.ExtendedDialog;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
+import org.openstreetmap.josm.tools.ImageProvider;
 
 /**
  * Dialog for selecting objects and configuring conflation settings
@@ -58,6 +60,8 @@ public class SettingsDialog extends ExtendedDialog {
                 tr("Configure conflation settings"),
                 new String[]{tr("Generate matches"), tr("Cancel")},
                 false);
+        setButtonIcons(new Icon[] {ImageProvider.get("ok"),
+                ImageProvider.get("cancel")});
         referenceSelection = new ArrayList<>();
         subjectSelection = new ArrayList<>();
         initComponents();


### PR DESCRIPTION
Improve the settings dialog with the following changes:
* align components to the left and add regular spaces among them
* add a "Layer:" label to explain the meaning of "(none)" string
* add icons to buttons
* translate the strings with the numbers of selected objects
* fix typo: "subject" --> "reference" in [SettingsDialog.java#L215](https://github.com/JOSM/josm-conflation-plugin/blob/master/src/org/openstreetmap/josm/plugins/conflation/SettingsDialog.java#L215)

Before:
![old_settingsdialog](https://cloud.githubusercontent.com/assets/5641204/11912775/53c793d0-a64d-11e5-8be4-7a16eaeb4487.png)

After:
![new_settingsdialog](https://cloud.githubusercontent.com/assets/5641204/11912776/5f8cc82a-a64d-11e5-805f-7530196bac27.png)

